### PR TITLE
feat(HGI-7817): auto POST bills

### DIFF
--- a/target_dynamics_v2/mappers/bill_expense_item_schema_mapper.py
+++ b/target_dynamics_v2/mappers/bill_expense_item_schema_mapper.py
@@ -45,15 +45,14 @@ class BillExpenseItemSchemaMapper(BaseMapper):
         if record_external_id := self.record.get("externalId"):
             found_record = next(
                 (line for line in self.existing_lines
-                if line["sequence"] == record_external_id),
+                if str(line["sequence"]) == record_external_id),
                 None
             )
 
-        record_account = self._map_account()
-        if (record_account_id := record_account.get("accountId")) and (record_description := self.record.get("description")):
+        if record_description := self.record.get("description"):
             found_record = next(
                 (line for line in self.existing_lines
-                if line["description"] == record_description and line["accountId"] == record_account_id),
+                if line["description"] == record_description),
                 None
             )
 

--- a/target_dynamics_v2/mappers/bill_line_item_schema_mapper.py
+++ b/target_dynamics_v2/mappers/bill_line_item_schema_mapper.py
@@ -45,7 +45,7 @@ class BillLineItemSchemaMapper(BaseMapper):
         if record_external_id := self.record.get("externalId"):
             found_record = next(
                 (line for line in self.existing_lines
-                if line["sequence"] == record_external_id),
+                if str(line["sequence"]) == record_external_id),
                 None
             )
 

--- a/target_dynamics_v2/mappers/bill_schema_mapper.py
+++ b/target_dynamics_v2/mappers/bill_schema_mapper.py
@@ -32,7 +32,9 @@ class BillSchemaMapper(BaseMapper):
 
         self._map_bill_line_items(payload)
 
-        return {"payload": payload, "company_id": self.company["id"]}
+        status = self.existing_record["status"] if self.existing_record else None
+
+        return {"payload": payload, "id": payload.get("id"), "company_id": self.company["id"], "status": status}
 
     def _map_bill_line_items(self, payload):
         mapped_line_items = []

--- a/target_dynamics_v2/sinks/bill_sink.py
+++ b/target_dynamics_v2/sinks/bill_sink.py
@@ -137,7 +137,7 @@ class BillSink(DynamicsBaseBatchSinkSingleUpsert):
         # if we sent locationId for any of the lines that lineType==Item we have to make another request to
         # update unitCost and discountAmount because Dynamics will have overriten that info with the Item
         # Catalog info for that item
-        bill_lines_upsert_request_data = []
+        bill_lines_update_request_data = []
         url_params = {"parentId": bill_id}
         for index, bill_line in enumerate(bill_lines):
             if not ("locationId" in bill_line and bill_line["lineType"] == "Item"):
@@ -159,12 +159,12 @@ class BillSink(DynamicsBaseBatchSinkSingleUpsert):
                 bill_line_payload["discountAmount"] = bill_line["discountAmount"]
 
             request_params = DynamicsClient.get_entity_upsert_request_params("purchaseInvoiceLines", company_id, entity_id=bill_line_id, url_params=url_params)
-            bill_lines_upsert_request_data.append({ **request_params, "body": bill_line_payload })
+            bill_lines_update_request_data.append({ **request_params, "body": bill_line_payload })
 
-        bill_lines_upsert_responses = self.dynamics_client.make_batch_request(bill_lines_upsert_request_data) if bill_lines_upsert_request_data else []
-        for bill_lines_upsert_response in bill_lines_upsert_responses:
-            if bill_lines_upsert_response.get("status") not in [200, 201]:
-                state["error"] = bill_lines_upsert_response.get("body", {}).get("error")
+        bill_lines_update_responses = self.dynamics_client.make_batch_request(bill_lines_update_request_data) if bill_lines_update_request_data else []
+        for bill_lines_update_response in bill_lines_update_responses:
+            if bill_lines_update_response.get("status") not in [200, 201]:
+                state["error"] = bill_lines_update_response.get("body", {}).get("error")
                 state["record"] = json.dumps(record, cls=HGJSONEncoder, sort_keys=True)
                 return bill_id, False, state
 

--- a/target_dynamics_v2/sinks/bill_sink.py
+++ b/target_dynamics_v2/sinks/bill_sink.py
@@ -139,7 +139,7 @@ class BillSink(DynamicsBaseBatchSinkSingleUpsert):
 
 
         # if we sent locationId for any of the lines that lineType==Item we have to make another request to
-        # update unitCost and discountAmount because Dynamics will have overriten that info with the Item
+        # update unitCost and discountAmount because Dynamics will have overwritten that info with the Item
         # Catalog info for that item
         bill_lines_update_request_data = []
         url_params = {"parentId": bill_id}

--- a/target_dynamics_v2/utils.py
+++ b/target_dynamics_v2/utils.py
@@ -9,6 +9,9 @@ class DimensionDefinitionNotFound(InvalidConfigurationError):
 class InvalidCustomFieldDefinition(InvalidConfigurationError):
     pass
 
+class InvalidRecordState(Exception):
+    pass
+
 class InvalidInputError(Exception):
     pass
 


### PR DESCRIPTION
- auto POST bills 
- fix issue when if we send `locationId` for any of the lines that `lineType==Item` we have to make another request to update `unitCost` and `discountAmount` because Dynamics will have overwritten that info with the Item Catalog info for that item
- only allow bill updates for bills in Draft state