### PR TITLE
HGI-10499|Add ruff linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install ruff
+        run: python -m pip install ruff
+      - name: Lint
+        run: ruff check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ pydocstyle = "^6.1.1"
 mypy = "^0.910"
 types-requests = "^2.26.1"
 isort = "^5.10.1"
+ruff = "^0.1.0"
 
 [tool.isort]
 profile = "black"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,19 @@
+target-version = "py310"
+line-length = 100
+
+exclude = [
+    ".git",
+    "__pycache__",
+    ".venv",
+    "venv",
+    "build",
+    "dist",
+    ".secrets",
+    ".vscode"
+]
+
+[lint]
+extend-select = ["C901"]
+ignore = []
+[lint.mccabe]
+max-complexity = 14

--- a/target_dynamics_bc/lambda.py
+++ b/target_dynamics_bc/lambda.py
@@ -13,7 +13,7 @@ def real_time_handler(
 
         if not hasattr(mod, "real_time_handler"):
             raise Exception("This target does not support real time")
-    except Exception as e:
+    except Exception:
         raise
 
     return mod.real_time_handler(

--- a/target_dynamics_bc/mappers/base_mappers.py
+++ b/target_dynamics_bc/mappers/base_mappers.py
@@ -380,7 +380,7 @@ class BaseMapper:
 
         if required:
             if vendor_id is None and vendor_number is None and vendor_name is None:
-                raise InvalidInputError(f"Vendor not informed. Please provide one of vendorId / vendorNumber / vendorName")
+                raise InvalidInputError("Vendor not informed. Please provide one of vendorId / vendorNumber / vendorName")
 
             if not found_vendor:
                 raise RecordNotFound(f"Vendor not found for vendorId={vendor_id} / vendorNumber={vendor_number} / vendorName={vendor_name}")
@@ -416,7 +416,7 @@ class BaseMapper:
 
         if required:
             if journal_id is None and journal_code is None:
-                raise InvalidInputError(f"Vendor payment journal not informed. Please provide one of journalId / journalExternalId")
+                raise InvalidInputError("Vendor payment journal not informed. Please provide one of journalId / journalExternalId")
 
             if not found_journal:
                 raise RecordNotFound(f"Vendor payment journal not found for journalId={journal_id} / journalExternalId={journal_code}")
@@ -502,7 +502,7 @@ class BaseMapper:
 
     def _map_fields(self, payload):
         for record_key, payload_key in self.field_mappings.items():
-            if record_key in self.record and self.record.get(record_key) != None:
+            if record_key in self.record and self.record.get(record_key) is not None:
                 if isinstance(payload_key, list):
                     for key in payload_key:
                         payload[key] = self.record.get(record_key)

--- a/target_dynamics_bc/mappers/bill_payment_schema_mapper.py
+++ b/target_dynamics_bc/mappers/bill_payment_schema_mapper.py
@@ -61,7 +61,7 @@ class BillPaymentSchemaMapper(BaseMapper):
     def _validate_external_id(self):
         external_id = self.record.get("externalId")
         if not external_id:
-            raise MissingField(f"The required field 'externalId' was not provided")
+            raise MissingField("The required field 'externalId' was not provided")
 
         if len(external_id) > 20:
             raise InvalidInputError(f"The length of externalId={external_id} should be less or equal to 20.")
@@ -96,7 +96,7 @@ class BillPaymentSchemaMapper(BaseMapper):
             )
 
         if bill_id is None and bill_invoice_number is None and bill_number is None:
-            raise InvalidInputError(f"Bill not informed. Please provide one of billId / billNumber / billExternalId")
+            raise InvalidInputError("Bill not informed. Please provide one of billId / billNumber / billExternalId")
 
         if not found_bill:
             raise RecordNotFound(f"Bill not found for billId={bill_id} / billNumber={bill_number} / billExternalId={bill_invoice_number}")

--- a/target_dynamics_bc/mappers/journal_entry_schema_mapper.py
+++ b/target_dynamics_bc/mappers/journal_entry_schema_mapper.py
@@ -1,7 +1,7 @@
 import hashlib
 from target_dynamics_bc.mappers.base_mappers import BaseMapper
 from target_dynamics_bc.mappers.journal_entry_line_schema_mapper import JournalEntryLineSchemaMapper
-from target_dynamics_bc.utils import InvalidInputError, MissingField, RecordNotFound
+from target_dynamics_bc.utils import InvalidInputError, MissingField
 
 class JournalEntrySchemaMapper(BaseMapper):
     name = "Journals"
@@ -37,21 +37,21 @@ class JournalEntrySchemaMapper(BaseMapper):
     def _validate_journal_entry_number(self):
         journal_entry_number = self.record.get("journalEntryNumber")
         if not journal_entry_number:
-            raise MissingField(f"The required field 'journalEntryNumber' was not provided")
+            raise MissingField("The required field 'journalEntryNumber' was not provided")
 
         if len(journal_entry_number) > 20:
             raise InvalidInputError(f"journalEntryNumber={journal_entry_number} is too long. The value must be less than or equal to 20 characters.")
 
     def _validate_transaction_date(self):
         if not self.record.get("transactionDate"):
-            raise MissingField(f"The required field 'transactionDate' was not provided")
+            raise MissingField("The required field 'transactionDate' was not provided")
 
     def _map_journal_entry_lines(self):
         lines = []
         transaction_date = self.record.get("transactionDate")
 
         if not self.record.get("lineItems", []):
-            raise MissingField(f"The required field 'lineItems' was not provided")
+            raise MissingField("The required field 'lineItems' was not provided")
 
         lines_amount_sum = 0
         for item in self.record.get("lineItems", []):

--- a/target_dynamics_bc/sinks/base_sinks.py
+++ b/target_dynamics_bc/sinks/base_sinks.py
@@ -258,7 +258,7 @@ class DynamicsBaseBatchSinkSingleUpsert(DynamicsBaseBatchSink):
         """
         pass
 
-    def process_batch(self, context: dict) -> None:
+    def process_batch(self, context: dict) -> None:  # noqa: C901
         if not self.latest_state:
             self.init_state()
 

--- a/target_dynamics_bc/sinks/bill_sink.py
+++ b/target_dynamics_bc/sinks/bill_sink.py
@@ -73,7 +73,7 @@ class BillSink(DynamicsBaseBatchSinkSingleUpsert):
         # perform the mapping
         return BillSchemaMapper(record, self, self.reference_data).to_dynamics()
 
-    def upsert_record(self, record: Dict) -> Tuple[str, bool, Dict]:
+    def upsert_record(self, record: Dict) -> Tuple[str, bool, Dict]:  # noqa: C901
         state = {}
         payload = record["payload"]
         
@@ -85,7 +85,7 @@ class BillSink(DynamicsBaseBatchSinkSingleUpsert):
         bill_lines = payload.pop("purchaseInvoiceLines", [])
 
         if is_update and record["status"] != "Draft":
-            raise InvalidRecordState(f"Cannot update a Bill that's not in Draft state")
+            raise InvalidRecordState("Cannot update a Bill that's not in Draft state")
 
         # create/update bill
         request_params = DynamicsClient.get_entity_upsert_request_params(self.record_type, company_id, bill_id)

--- a/target_dynamics_bc/target.py
+++ b/target_dynamics_bc/target.py
@@ -42,13 +42,13 @@ class TargetDynamicsV2(TargetHotglue):
         self.dimensions_mapping = self.load_fields_and_dimensions_mapping_config()
 
     def get_reference_data(self) -> ReferenceData:
-        self.logger.info(f"Getting reference data...")
+        self.logger.info("Getting reference data...")
 
         reference_data: ReferenceData = ReferenceData()
         _, _, companies = self.dynamics_client.get_companies()
         reference_data["companies"] = companies
 
-        self.logger.info(f"Done getting reference data...")
+        self.logger.info("Done getting reference data...")
         return reference_data
 
     def validate_dimensions_mapping(self, dimensions_mapping: dict):
@@ -87,7 +87,7 @@ class TargetDynamicsV2(TargetHotglue):
         tenant_config = self.get_tenant_config()
         dynamics_config = tenant_config.get("dynamics-bc")
 
-        if dynamics_config == None:
+        if dynamics_config is None:
             raise InvalidConfigurationError("dynamics-bc is not provided in the tenant-config.json")
 
         dimensions_mapping = dynamics_config.get("dimension_mappings", {})

--- a/target_dynamics_bc/tests/test_core.py
+++ b/target_dynamics_bc/tests/test_core.py
@@ -1,6 +1,5 @@
 """Tests standard target features using the built-in SDK tests library."""
 
-import datetime
 
 from typing import Dict, Any
 


### PR DESCRIPTION
Sets up [ruff](https://docs.astral.sh/ruff/) linting for the repo.

- Adds `ruff.toml` (py310 target, line length 100, mccabe complexity check) matching the config used in our other connectors.
- Adds a `Lint` GitHub Actions workflow that runs `ruff check .` on push and PR.
- Adds `ruff` to dev dependencies.
- Applies the benign formatting fixes needed to pass: dropping redundant `f` prefixes on f-strings without placeholders, removing unused imports, `== None` → `is None`, and an unused exception binding. The two functions that exceed the complexity threshold are annotated with `# noqa: C901` rather than refactored, to keep this change purely formatting.
