### PR TITLE
feature/hgi-10567 | Migrated imports to HotglueSingerSDK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,7 @@ license = "Apache 2.0"
 [tool.poetry.dependencies]
 python = "<3.11,>=3.7.1"
 requests = "^2.25.1"
-singer-sdk = "^0.9.0"
-target-hotglue = "^0.1.7"
+hotglue-singer-sdk = "^1.0.36"
 hotglue-models-accounting = { git = "https://gitlab.com/hotglue/hotglue-models-accounting.git", rev = "v2" }
 typing_extensions = "^4.0.0"
 

--- a/target_dynamics_bc/client.py
+++ b/target_dynamics_bc/client.py
@@ -2,7 +2,7 @@ import json
 import requests
 
 from target_dynamics_bc.mappers.base_mappers import BaseMapper
-from target_hotglue.common import HGJSONEncoder
+from hotglue_singer_sdk.target_sdk.common import HGJSONEncoder
 from typing import Dict, List, Optional, Tuple
 import singer
 

--- a/target_dynamics_bc/lambda.py
+++ b/target_dynamics_bc/lambda.py
@@ -9,7 +9,7 @@ def real_time_handler(
     logger: Logger,
 ):
     try:
-        mod = importlib.import_module("target_hotglue.lambda")
+        mod = importlib.import_module("hotglue_singer_sdk.target_sdk.lambda")
 
         if not hasattr(mod, "real_time_handler"):
             raise Exception("This target does not support real time")

--- a/target_dynamics_bc/sinks/base_sinks.py
+++ b/target_dynamics_bc/sinks/base_sinks.py
@@ -3,10 +3,10 @@ import hashlib
 import json
 from typing import Dict, List, Optional, Tuple
 
-from singer_sdk.plugin_base import PluginBase
-from singer_sdk.sinks import BatchSink
-from target_hotglue.client import HotglueBaseSink
-from target_hotglue.common import HGJSONEncoder
+from hotglue_singer_sdk.plugin_base import PluginBase
+from hotglue_singer_sdk.sinks import BatchSink
+from hotglue_singer_sdk.target_sdk.client import HotglueBaseSink
+from hotglue_singer_sdk.target_sdk.common import HGJSONEncoder
 
 from target_dynamics_bc.client import DynamicsClient
 from target_dynamics_bc.utils import extract_error_message

--- a/target_dynamics_bc/target.py
+++ b/target_dynamics_bc/target.py
@@ -2,8 +2,8 @@
 import json
 import os
 
-from singer_sdk import typing as th
-from target_hotglue.target import TargetHotglue
+from hotglue_singer_sdk import typing as th
+from hotglue_singer_sdk.target_sdk.target import TargetHotglue
 
 from target_dynamics_bc.client import DynamicsClient
 from target_dynamics_bc.sinks.bill_payment_sink import BillPaymentSink

--- a/target_dynamics_bc/tests/test_core.py
+++ b/target_dynamics_bc/tests/test_core.py
@@ -3,7 +3,7 @@
 
 from typing import Dict, Any
 
-from singer_sdk.testing import get_standard_target_tests
+from hotglue_singer_sdk.testing import get_standard_target_tests
 
 from target_dynamics_bc.target import TargetDynamicsV2
 

--- a/target_dynamics_bc/utils.py
+++ b/target_dynamics_bc/utils.py
@@ -2,7 +2,7 @@ import json
 from typing import List, Optional
 from typing_extensions import TypedDict
 
-from target_hotglue.common import HGJSONEncoder
+from hotglue_singer_sdk.target_sdk.common import HGJSONEncoder
 
 
 def extract_error_message(response: dict) -> Optional[str]:


### PR DESCRIPTION
Upgraded the imports and dependencies to use HotglueSingerSDK over singer-sdk and target-hotglue

Verified the target loads locally with new refactoring:
<img width="845" height="418" alt="image" src="https://github.com/user-attachments/assets/fd6627f9-5fd4-421c-8b57-bb5ffd906d6a" />
